### PR TITLE
moved the popup it doesnt overlap with marker

### DIFF
--- a/src/js/map.js
+++ b/src/js/map.js
@@ -21,7 +21,10 @@ $(document).ready(function() {
 
     function onEachFeature(feature, layer) {
         if (feature.properties) {
-            layer.bindPopup(popuptemplate(feature.properties));
+            var popup = L.popup({
+              offset: new L.point(0, -6) //Offset needed, marker and popup can't overlap
+            }).setContent(popuptemplate(feature.properties));
+            layer.bindPopup(popup);
         }
     }
 


### PR DESCRIPTION
Popup funkyness zou nu moeten gefixed zijn door de popup een beetje naar boven te schuiven zodat die niet onder de muis komt en de 'mouseout' van de marker triggered.