### PR TITLE
Anonymize IP addresses in Google Analytics

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -129,6 +129,7 @@
     })(window,document,"script","//www.google-analytics.com/analytics.js","ga");
 
     ga("create", "UA-25444917-8", "auto");
+    ga('set', 'anonymizeIp', true);
     ga("send", "pageview");
   </script>
 </body>


### PR DESCRIPTION
This is necessary to comply with our privacy policy and fixes #34.